### PR TITLE
Allow users to change their name in game

### DIFF
--- a/client/src/context/useToggle.jsx
+++ b/client/src/context/useToggle.jsx
@@ -1,0 +1,11 @@
+import { useCallback, useState } from "react";
+
+function useToggle(initialState = false) {
+  const [state, setState] = useState(initialState);
+
+  const toggle = useCallback(() => setState((bool) => !bool), []);
+
+  return [state, toggle];
+}
+
+export default useToggle;

--- a/client/src/pages/Create.jsx
+++ b/client/src/pages/Create.jsx
@@ -6,7 +6,6 @@ import useStyles from "./styles";
 import BackButton from "../components/BackButton";
 
 function Create() {
-
   const { userId } = useUser();
   const [capacity, setCapacity] = useState("");
   const history = useHistory();

--- a/client/src/pages/room/Room.jsx
+++ b/client/src/pages/room/Room.jsx
@@ -30,6 +30,7 @@ function Room() {
       lastMessage.banned.map(({ id }) => id).includes(me.id) // better than object comparison
     )
       history.push(
+        // eslint-disable-next-line prefer-template
         "/home/" +
           encodeURIComponent(`You have been banned from room ${roomName}.`)
       );

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -47,7 +47,6 @@ function User({ name, userId, myId, userIsMod }) {
           type="text"
           className={classes.smallBox}
           value={nextName}
-          placeholder="Enter a new username"
           onKeyUp={changeNameKeyEvent}
           onInput={(e) => setNextName(e.target.value)}
           disabled={!canChangeName || !changingName}

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -10,6 +10,13 @@ function User({ name, userId, myId, userIsMod }) {
   const [changingName, toggleChangingName] = useToggle();
   const [nextName, setNextName] = useState(name);
 
+  const canChangeName = myId === userId;
+
+  // TODO:
+  // - disable changing name for people who are not you
+  // - when clicking the username box, focus the window to edit the username
+  // - show explicit change name button
+
   const changeName = useCallback(() => {
     sendMessage({ type: "changeName", payload: { name: nextName } });
     toggleChangingName();
@@ -47,7 +54,7 @@ function User({ name, userId, myId, userIsMod }) {
           key={userId}
           role="button"
           tabIndex={0}
-          onKeyDown={(e) => e.key === "Enter" && changeName()}
+          onKeyDown={(e) => e.key === "Enter" && startChangingName()}
           onClick={() => startChangingName()}
         >
           <p>{name}</p>

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -63,10 +63,7 @@ function User({ name, userId, myId, userIsMod }) {
           </button>
         )
       ) : (
-        <>
-          <p>Me</p>
-          {userIsMod && <p>Mod</p>}
-        </>
+        <p>Me{userIsMod && ", Mod"}</p>
       )}
     </div>
   );

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -1,3 +1,4 @@
+import { useState, useCallback } from "react";
 import PropTypes from "prop-types";
 import { useSocket } from "../../context/socketContext";
 import useStyles from "./styles";
@@ -5,10 +6,54 @@ import useStyles from "./styles";
 function User({ name, userId, myId, userIsMod }) {
   const { sendMessage } = useSocket();
   const classes = useStyles();
+  const [changingName, setChangingName] = useState(false);
+  const [nextName, setNextName] = useState(name);
+
+  const changeName = useCallback(() => {
+    // Change the current user's username
+    sendMessage({ type: "changeName", payload: { name: nextName } });
+    // Reset the state of the component
+    setChangingName((b) => !b);
+    setNextName("");
+  }, [sendMessage, nextName, setChangingName, setNextName]);
+
+  const startChangingName = useCallback(() => {
+    setNextName(name);
+    setChangingName((b) => !b);
+  }, [name]);
 
   return (
     <div key={`userBox-${userId}`} className={classes.userBox}>
-      <p key={userId}>{name}</p>
+      {changingName ? (
+        <>
+          <input
+            type="text"
+            className={classes.box}
+            value={nextName}
+            placeholder="Enter a new username"
+            onKeyUp={(e) => e.key === "Enter" && changeName()}
+            onInput={(e) => setNextName(e.target.value)}
+          />
+          <button
+            type="button"
+            className={classes.box}
+            onClick={() => changeName()}
+            onKeyDown={(e) => e.key === "Enter" && changeName()}
+          >
+            Save
+          </button>
+        </>
+      ) : (
+        <div
+          key={userId}
+          role="button"
+          onClick={() => {
+            setChangingName((b) => !b);
+          }}
+        >
+          <p>{name}</p>
+        </div>
+      )}
       {myId !== userId ? (
         userIsMod && (
           <button

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -23,10 +23,10 @@ function User({ name, userId, myId, userIsMod }) {
   return (
     <div key={`userBox-${userId}`} className={classes.userBox}>
       {changingName ? (
-        <>
+        <div className={classes.changeUserBox}>
           <input
             type="text"
-            className={classes.box}
+            className={classes.smallBox}
             value={nextName}
             placeholder="Enter a new username"
             onKeyUp={(e) => e.key === "Enter" && changeName()}
@@ -34,15 +34,22 @@ function User({ name, userId, myId, userIsMod }) {
           />
           <button
             type="button"
-            className={classes.box}
+            tabIndex={0}
+            className={classes.userSaveButton}
             onClick={() => changeName()}
             onKeyDown={(e) => e.key === "Enter" && changeName()}
           >
             Save
           </button>
-        </>
+        </div>
       ) : (
-        <div key={userId} role="button" onClick={() => startChangingName()}>
+        <div
+          key={userId}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => e.key === "Enter" && changeName()}
+          onClick={() => startChangingName()}
+        >
           <p>{name}</p>
         </div>
       )}

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -31,8 +31,14 @@ function User({ name, userId, myId, userIsMod }) {
 
   return (
     <div key={`userBox-${userId}`} className={classes.userBox}>
-      {changingName ? (
-        <div className={classes.changeUserBox}>
+      <div className={classes.changeUserBox}>
+        <div
+          role="button"
+          onClick={() => startChangingName()}
+          onKeyUp={(e) => e.key === "Enter" && startChangingName()}
+          tabIndex={canChangeName ? 0 : -1}
+          disabled={!canChangeName}
+        >
           <input
             type="text"
             className={classes.smallBox}
@@ -40,8 +46,11 @@ function User({ name, userId, myId, userIsMod }) {
             placeholder="Enter a new username"
             onKeyUp={(e) => e.key === "Enter" && changeName()}
             onInput={(e) => setNextName(e.target.value)}
+            disabled={!canChangeName || !changingName}
             ref={editNameBoxRef}
           />
+        </div>
+        {canChangeName && (
           <button
             type="button"
             tabIndex={0}
@@ -49,36 +58,10 @@ function User({ name, userId, myId, userIsMod }) {
             onClick={() => changeName()}
             onKeyDown={(e) => e.key === "Enter" && changeName()}
           >
-            Save
+            {changingName ? "Save" : "Edit Name"}
           </button>
-        </div>
-      ) : (
-        <>
-          <div
-            role="button"
-            key={userId}
-            tabIndex={canChangeName ? 0 : null}
-            onKeyDown={(e) => e.key === "Enter" && startChangingName()}
-            onClick={() => canChangeName && startChangingName()}
-            disabled={!canChangeName}
-          >
-            <p>{name}</p>
-          </div>
-          {canChangeName && (
-            <button
-              type="button"
-              tabIndex={0}
-              className={classes.userSaveButton}
-              onClick={() => startChangingName()}
-              onKeyDown={(e) =>
-                e.key === "Enter" && canChangeName && startChangingName()
-              }
-            >
-              Edit Name
-            </button>
-          )}
-        </>
-      )}
+        )}
+      </div>
       {myId !== userId ? (
         userIsMod && (
           <button

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -22,9 +22,8 @@ function User({ name, userId, myId, userIsMod }) {
   const startChangingName = useCallback(() => {
     setNextName(name);
     toggleChangingName();
-    if (editNameBoxRef && editNameBoxRef.current)
-      editNameBoxRef.current.focus();
-  }, [name, toggleChangingName, editNameBoxRef]);
+    if (editNameBoxRef.current) editNameBoxRef.current.focus();
+  }, [name, toggleChangingName]);
 
   useEffect(() => {
     if (changingName) editNameBoxRef.current.focus();
@@ -58,7 +57,7 @@ function User({ name, userId, myId, userIsMod }) {
           <div
             role="button"
             key={userId}
-            tabIndex={0}
+            tabIndex={canChangeName ? 0 : null}
             onKeyDown={(e) => e.key === "Enter" && startChangingName()}
             onClick={() => canChangeName && startChangingName()}
             disabled={!canChangeName}

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -43,24 +43,16 @@ function User({ name, userId, myId, userIsMod }) {
   return (
     <div key={`userBox-${userId}`} className={classes.userBox}>
       <div className={classes.changeUserBox}>
-        <div
-          role="button"
-          onClick={() => !changingName && startChangingName()}
+        <input
+          type="text"
+          className={classes.smallBox}
+          value={nextName}
+          placeholder="Enter a new username"
           onKeyUp={changeNameKeyEvent}
-          tabIndex={canChangeName ? 0 : -1}
-          disabled={!canChangeName}
-        >
-          <input
-            type="text"
-            className={classes.smallBox}
-            value={nextName}
-            placeholder="Enter a new username"
-            onKeyUp={changeNameKeyEvent}
-            onInput={(e) => setNextName(e.target.value)}
-            disabled={!canChangeName && !changingName}
-            ref={editNameBoxRef}
-          />
-        </div>
+          onInput={(e) => setNextName(e.target.value)}
+          disabled={!canChangeName || !changingName}
+          ref={editNameBoxRef}
+        />
         {canChangeName && (
           <button
             type="button"

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -29,17 +29,6 @@ function User({ name, userId, myId, userIsMod }) {
     if (changingName) editNameBoxRef.current.focus();
   }, [changingName]);
 
-  const changeNameKeyEvent = useCallback(
-    (e) =>
-      e.key === "Enter" && (changingName ? changeName() : startChangingName()),
-    [changingName, changeName, startChangingName]
-  );
-
-  const changeNameEvent = useCallback(
-    () => (changingName ? changeName() : startChangingName()),
-    [changingName, changeName, startChangingName]
-  );
-
   return (
     <div key={`userBox-${userId}`} className={classes.userBox}>
       <div className={classes.changeUserBox}>
@@ -47,7 +36,10 @@ function User({ name, userId, myId, userIsMod }) {
           type="text"
           className={classes.smallBox}
           value={nextName}
-          onKeyUp={changeNameKeyEvent}
+          onKeyUp={(e) =>
+            e.key === "Enter" &&
+            (changingName ? changeName() : startChangingName())
+          }
           onInput={(e) => setNextName(e.target.value)}
           disabled={!canChangeName || !changingName}
           ref={editNameBoxRef}
@@ -57,8 +49,11 @@ function User({ name, userId, myId, userIsMod }) {
             type="button"
             tabIndex={0}
             className={classes.userSaveButton}
-            onClick={changeNameEvent}
-            onKeyDown={changeNameKeyEvent}
+            onClick={(e) => (changingName ? changeName() : startChangingName())}
+            onKeyUp={(e) =>
+              e.key === "Enter" &&
+              (changingName ? changeName() : startChangingName())
+            }
           >
             {changingName ? "Save" : "Edit Name"}
           </button>

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -1,26 +1,24 @@
 import { useState, useCallback } from "react";
 import PropTypes from "prop-types";
 import { useSocket } from "../../context/socketContext";
+import useToggle from "../../context/useToggle";
 import useStyles from "./styles";
 
 function User({ name, userId, myId, userIsMod }) {
   const { sendMessage } = useSocket();
   const classes = useStyles();
-  const [changingName, setChangingName] = useState(false);
+  const [changingName, toggleChangingName] = useToggle();
   const [nextName, setNextName] = useState(name);
 
   const changeName = useCallback(() => {
-    // Change the current user's username
     sendMessage({ type: "changeName", payload: { name: nextName } });
-    // Reset the state of the component
-    setChangingName((b) => !b);
-    setNextName("");
-  }, [sendMessage, nextName, setChangingName, setNextName]);
+    toggleChangingName();
+  }, [sendMessage, nextName, toggleChangingName]);
 
   const startChangingName = useCallback(() => {
     setNextName(name);
-    setChangingName((b) => !b);
-  }, [name]);
+    toggleChangingName();
+  }, [name, toggleChangingName]);
 
   return (
     <div key={`userBox-${userId}`} className={classes.userBox}>
@@ -44,13 +42,7 @@ function User({ name, userId, myId, userIsMod }) {
           </button>
         </>
       ) : (
-        <div
-          key={userId}
-          role="button"
-          onClick={() => {
-            setChangingName((b) => !b);
-          }}
-        >
+        <div key={userId} role="button" onClick={() => startChangingName()}>
           <p>{name}</p>
         </div>
       )}

--- a/client/src/pages/room/styles.js
+++ b/client/src/pages/room/styles.js
@@ -6,9 +6,30 @@ export default createUseStyles((theme) => ({
     flexDirection: "row",
     justifyContent: "space-between",
   },
+  changeUserBox: {
+    display: "flex",
+    flexDirection: "row",
+    margin: "auto",
+  },
+  smallBox: {
+    border: `2px solid ${theme.black}`,
+    padding: "0.5em 0.5em",
+    color: theme.black,
+    backgroundColor: theme.white,
+  },
   banButton: {
     border: `2px solid ${theme.red}`,
     padding: "auto",
+    color: theme.black,
     backgroundColor: theme.white,
+  },
+  userSaveButton: {
+    border: `2px solid ${theme.black}`,
+    padding: "auto",
+    color: theme.black,
+    backgroundColor: theme.white,
+    marginLeft: "0.5em",
+    paddingTop: "0.5em",
+    paddingBottom: "0.5em",
   },
 }));

--- a/client/src/pages/room/styles.js
+++ b/client/src/pages/room/styles.js
@@ -5,6 +5,7 @@ export default createUseStyles((theme) => ({
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-between",
+    alignItems: "center",
   },
   changeUserBox: {
     display: "flex",
@@ -14,6 +15,7 @@ export default createUseStyles((theme) => ({
   smallBox: {
     border: `2px solid ${theme.black}`,
     padding: "0.5em 0.5em",
+    textAlign: "center",
     color: theme.black,
     backgroundColor: theme.white,
   },

--- a/server/app.js
+++ b/server/app.js
@@ -17,6 +17,7 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));
 
 // api requests won't work without this
+// TODO: remove this for security reasons later
 app.use((req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");
   res.header(

--- a/server/sockets/socketActions.js
+++ b/server/sockets/socketActions.js
@@ -1,5 +1,6 @@
 const WebSocket = require("ws");
 const Rooms = require("../engine/rooms");
+const Users = require("../engine/users");
 
 function broadcast(wss, message) {
   wss.clients.forEach((client) => {
@@ -38,6 +39,11 @@ function banUser(wss, message, { roomName, userId }) {
   updateUsers(wss, message, { roomName });
 }
 
+function changeName(wss, message, { roomName, userId }) {
+  Users.setName(userId, message.payload.name);
+  updateUsers(wss, message, { roomName });
+}
+
 const socketActions = {
   connect,
   disconnect,
@@ -45,6 +51,7 @@ const socketActions = {
   spectate,
   unspectate,
   banUser,
+  changeName,
 };
 
 module.exports = socketActions;


### PR DESCRIPTION
Uses existing infrastructure for allowing users to change their name on the profile page on the server side, so there aren't any substantial additions to the code.

It's worth noting that the client-side HTTP request was not used for name changes; rather, a new socket message was added. As we want the user provider to contain the socket provider (user should encompass everything, socket should only contain room) this is better.

There are no current username limitations. Still not sure how I feel about that.