### PR TITLE
Enforce moderation of spectators

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,7 @@ module.exports = {
     "react/prop-types": "warn",
     "jsx-a11y/click-events-have-key-events": "warn",
     "jsx-a11y/interactive-supports-focus": "warn",
+    "jsx-a11y/label-has-associated-control": "warn",
 
     // personal preference
     "react/jsx-props-no-spreading": "off",

--- a/client/src/pages/Create.jsx
+++ b/client/src/pages/Create.jsx
@@ -5,20 +5,35 @@ import useStyles from "./styles";
 
 import BackButton from "../components/BackButton";
 
+// Determines whether users spectate.
+const RoomBehavior = {
+  USER_SPECTATE: "user-spectate",
+  MOD_SPECTATE: "mod-spectate",
+};
+
 function Create() {
   const { userId } = useUser();
   const [capacity, setCapacity] = useState("");
+  const [roomEnterBehavior, setEnterBehavior] = useState(
+    RoomBehavior.USER_SPECTATE
+  );
   const history = useHistory();
   const classes = useStyles();
 
   const createRoom = useCallback(() => {
     if (userId) {
       const cap = capacity || "-1";
-      fetch(`/room/new?${new URLSearchParams({ userId, capacity: cap })}`)
+      fetch(
+        `/room/new?${new URLSearchParams({
+          userId,
+          capacity: cap,
+          roomEnterBehavior,
+        })}`
+      )
         .then((res) => res.json())
         .then((room) => history.push(`/room/${room.name}`));
     }
-  }, [userId, history, capacity]);
+  }, [userId, history, capacity, roomEnterBehavior]);
 
   return (
     <div className={classes.home}>
@@ -31,6 +46,28 @@ function Create() {
         onKeyUp={(e) => e.key === "Enter" && createRoom()}
         onInput={(e) => setCapacity(e.target.value.toUpperCase())}
       />
+      <div className={classes.box}>
+        <input
+          type="radio"
+          value={RoomBehavior.USER_SPECTATE}
+          id={RoomBehavior.USER_SPECTATE}
+          onChange={() => setEnterBehavior(RoomBehavior.USER_SPECTATE)}
+          name="gender"
+        />
+        <label htmlFor={RoomBehavior.USER_SPECTATE}>
+          Users choose to spectate
+        </label>
+        <input
+          type="radio"
+          value={RoomBehavior.MOD_SPECTATE}
+          id={RoomBehavior.MOD_SPECTATE}
+          onChange={() => setEnterBehavior(RoomBehavior.MOD_SPECTATE)}
+          name="gender"
+        />
+        <label htmlFor={RoomBehavior.MOD_SPECTATE}>
+          Moderator manages spectators
+        </label>
+      </div>
       <button
         type="button"
         className={classes.box}

--- a/client/src/pages/Create.jsx
+++ b/client/src/pages/Create.jsx
@@ -5,18 +5,9 @@ import useStyles from "./styles";
 
 import BackButton from "../components/BackButton";
 
-// Determines whether users spectate.
-const RoomBehavior = {
-  USER_SPECTATE: "user-spectate",
-  MOD_SPECTATE: "mod-spectate",
-};
-
 function Create() {
   const { userId } = useUser();
   const [capacity, setCapacity] = useState("");
-  const [roomEnterBehavior, setEnterBehavior] = useState(
-    RoomBehavior.USER_SPECTATE
-  );
   const history = useHistory();
   const classes = useStyles();
 
@@ -27,13 +18,12 @@ function Create() {
         `/room/new?${new URLSearchParams({
           userId,
           capacity: cap,
-          roomEnterBehavior,
         })}`
       )
         .then((res) => res.json())
         .then((room) => history.push(`/room/${room.name}`));
     }
-  }, [userId, history, capacity, roomEnterBehavior]);
+  }, [userId, history, capacity]);
 
   return (
     <div className={classes.home}>
@@ -46,28 +36,6 @@ function Create() {
         onKeyUp={(e) => e.key === "Enter" && createRoom()}
         onInput={(e) => setCapacity(e.target.value.toUpperCase())}
       />
-      <div className={classes.box}>
-        <input
-          type="radio"
-          value={RoomBehavior.USER_SPECTATE}
-          id={RoomBehavior.USER_SPECTATE}
-          onChange={() => setEnterBehavior(RoomBehavior.USER_SPECTATE)}
-          name="gender"
-        />
-        <label htmlFor={RoomBehavior.USER_SPECTATE}>
-          Users choose to spectate
-        </label>
-        <input
-          type="radio"
-          value={RoomBehavior.MOD_SPECTATE}
-          id={RoomBehavior.MOD_SPECTATE}
-          onChange={() => setEnterBehavior(RoomBehavior.MOD_SPECTATE)}
-          name="gender"
-        />
-        <label htmlFor={RoomBehavior.MOD_SPECTATE}>
-          Moderator manages spectators
-        </label>
-      </div>
       <button
         type="button"
         className={classes.box}

--- a/client/src/pages/room/PlayerList.jsx
+++ b/client/src/pages/room/PlayerList.jsx
@@ -3,32 +3,16 @@ import { useSocket } from "../../context/socketContext";
 import User from "./User";
 import useStyles from "../styles";
 
-function SpectatorList({ users, capacity, myId, userIsMod }) {
+function PlayerList({ users, capacity, myId, userIsMod }) {
   const classes = useStyles();
   const { sendMessage } = useSocket();
 
   return users && users.length > 0 ? (
     <>
-      <div className={classes.flexRow}>
-        <div>
-          Spectators
-          {capacity &&
-            `: ${users && users.length}/${capacity >= 0 ? capacity : "∞"}`}
-        </div>
-        {userIsMod && (
-          <button
-            type="button"
-            className={classes.box}
-            onClick={() =>
-              sendMessage &&
-              sendMessage({
-                type: "unspectateAll",
-              })
-            }
-          >
-            Admit All
-          </button>
-        )}
+      <div>
+        Players
+        {capacity &&
+          `: ${users && users.length}/${capacity >= 0 ? capacity : "∞"}`}
       </div>
       <div className={classes.box}>
         {users &&
@@ -42,6 +26,7 @@ function SpectatorList({ users, capacity, myId, userIsMod }) {
                   myId={myId}
                   userIsMod={userIsMod}
                   userIsSpectator
+                  playerList
                 />
               )
           )}
@@ -50,7 +35,7 @@ function SpectatorList({ users, capacity, myId, userIsMod }) {
   ) : null;
 }
 
-SpectatorList.propTypes = {
+PlayerList.propTypes = {
   users: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -62,8 +47,8 @@ SpectatorList.propTypes = {
   userIsMod: PropTypes.bool.isRequired,
 };
 
-SpectatorList.defaultProps = {
+PlayerList.defaultProps = {
   capacity: null,
 };
 
-export default SpectatorList;
+export default PlayerList;

--- a/client/src/pages/room/Room.jsx
+++ b/client/src/pages/room/Room.jsx
@@ -105,13 +105,15 @@ function Room() {
               userIsMod={userIsMod}
               myId={me.id}
             />
-            <button
-              type="button"
-              className={classes.box}
-              onClick={sendSpectateMessage}
-            >
-              {userIsNotSpectator ? "Spectate" : "Unspectate"}
-            </button>
+            {(userIsMod || userIsNotSpectator) && (
+              <button
+                type="button"
+                className={classes.box}
+                onClick={sendSpectateMessage}
+              >
+                {userIsNotSpectator ? "Spectate" : "Unspectate"}
+              </button>
+            )}
           </>
         )}
       </div>

--- a/client/src/pages/room/Room.jsx
+++ b/client/src/pages/room/Room.jsx
@@ -81,7 +81,6 @@ function Room() {
               userIsMod={userIsMod}
               myId={me.id}
             />
-
             <button
               type="button"
               className={classes.box}

--- a/client/src/pages/room/Room.jsx
+++ b/client/src/pages/room/Room.jsx
@@ -5,6 +5,7 @@ import BackButton from "../../components/BackButton";
 import { useSocket } from "../../context/socketContext";
 import { useUser } from "../../context/userContext";
 import UserList from "./UserList";
+import SpectatorList from "./SpectatorList";
 
 function userIsNotSpectator(userId, players) {
   const meHopefully = players.filter(({ id }) => id === userId);
@@ -93,11 +94,9 @@ function Room() {
               userIsMod={userIsMod}
               myId={me.id}
             />
-            <UserList
+            <SpectatorList
               users={lastMessage.spectators}
-              title="Spectators"
               userIsMod={userIsMod}
-              userIsSpectator
               myId={me.id}
             />
             <UserList

--- a/client/src/pages/room/Room.jsx
+++ b/client/src/pages/room/Room.jsx
@@ -73,9 +73,9 @@ function Room() {
     () =>
       sendMessage &&
       sendMessage({
-        type: userIsSpectator ? "unspectate" : "spectate",
+        type: "spectate",
       }),
-    [sendMessage, userIsSpectator]
+    [sendMessage]
   );
 
   return (
@@ -111,7 +111,7 @@ function Room() {
                 className={classes.box}
                 onClick={sendSpectateMessage}
               >
-                {userIsSpectator ? "Unspectate" : "Spectate"}
+                Spectate
               </button>
             )}
           </>

--- a/client/src/pages/room/Room.jsx
+++ b/client/src/pages/room/Room.jsx
@@ -7,7 +7,7 @@ import { useUser } from "../../context/userContext";
 import UserList from "./UserList";
 import SpectatorList from "./SpectatorList";
 
-function userIsNotSpectator(userId, players) {
+function hasSpectator(userId, players) {
   const meHopefully = players.filter(({ id }) => id === userId);
   return meHopefully && meHopefully[0] && !meHopefully.spectate;
 }
@@ -59,13 +59,13 @@ function Room() {
     [me, lastMessage]
   );
 
-  const userIsSpectator = !useMemo(
+  const userIsSpectator = useMemo(
     () =>
       me &&
       me.id &&
       lastMessage &&
       lastMessage.players &&
-      userIsNotSpectator(me.id, lastMessage.players),
+      hasSpectator(me.id, lastMessage.players),
     [me, lastMessage]
   );
 
@@ -105,7 +105,7 @@ function Room() {
               userIsMod={userIsMod}
               myId={me.id}
             />
-            {(userIsMod || userIsNotSpectator) && (
+            {userIsSpectator && (
               <button
                 type="button"
                 className={classes.box}

--- a/client/src/pages/room/Room.jsx
+++ b/client/src/pages/room/Room.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import { useHistory } from "react-router-dom";
 import useStyles from "../styles";
 import BackButton from "../../components/BackButton";
@@ -68,6 +68,15 @@ function Room() {
     [me, lastMessage]
   );
 
+  const sendSpectateMessage = useCallback(
+    () =>
+      sendMessage &&
+      sendMessage({
+        type: userIsNotSpectator ? "spectate" : "unspectate",
+      }),
+    [sendMessage, userIsNotSpectator]
+  );
+
   return (
     <>
       <div className={classes.room}>
@@ -99,12 +108,7 @@ function Room() {
             <button
               type="button"
               className={classes.box}
-              onClick={() =>
-                sendMessage &&
-                sendMessage({
-                  type: userIsNotSpectator ? "spectate" : "unspectate",
-                })
-              }
+              onClick={sendSpectateMessage}
             >
               {userIsNotSpectator ? "Spectate" : "Unspectate"}
             </button>

--- a/client/src/pages/room/Room.jsx
+++ b/client/src/pages/room/Room.jsx
@@ -6,6 +6,7 @@ import { useSocket } from "../../context/socketContext";
 import { useUser } from "../../context/userContext";
 import UserList from "./UserList";
 import SpectatorList from "./SpectatorList";
+import PlayerList from "./PlayerList";
 
 function hasSpectator(userId, players) {
   const meHopefully = players.filter(({ id }) => id === userId);
@@ -87,9 +88,8 @@ function Room() {
         </div>
         {!error && lastMessage && (
           <>
-            <UserList
+            <PlayerList
               users={lastMessage.players}
-              title="Players"
               capacity={room && room.capacity}
               userIsMod={userIsMod}
               myId={me.id}

--- a/client/src/pages/room/Room.jsx
+++ b/client/src/pages/room/Room.jsx
@@ -45,11 +45,26 @@ function Room() {
   const userIsMod = useMemo(
     () =>
       me &&
-      lastMessage &&
       me.id &&
+      lastMessage &&
       lastMessage.players &&
       lastMessage.players[0] &&
       lastMessage.players[0].id === me.id,
+    [me, lastMessage]
+  );
+
+  const userIsNotSpectator = useMemo(
+    () =>
+      me &&
+      me.id &&
+      lastMessage &&
+      lastMessage.players &&
+      (() => {
+        const meHopefully = lastMessage.players.filter(
+          ({ id }) => id === me.id
+        );
+        return meHopefully && meHopefully[0] && !meHopefully.spectate;
+      })(),
     [me, lastMessage]
   );
 
@@ -84,16 +99,14 @@ function Room() {
             <button
               type="button"
               className={classes.box}
-              onClick={() => sendMessage && sendMessage({ type: "spectate" })}
+              onClick={() =>
+                sendMessage &&
+                sendMessage({
+                  type: userIsNotSpectator ? "spectate" : "unspectate",
+                })
+              }
             >
-              Spectate
-            </button>
-            <button
-              type="button"
-              className={classes.box}
-              onClick={() => sendMessage && sendMessage({ type: "unspectate" })}
-            >
-              Unspectate
+              {userIsNotSpectator ? "Spectate" : "Unspectate"}
             </button>
           </>
         )}

--- a/client/src/pages/room/SpectatorList.jsx
+++ b/client/src/pages/room/SpectatorList.jsx
@@ -30,7 +30,6 @@ function SpectatorList({ users, capacity, myId, userIsMod, userIsSpectator }) {
           </button>
         )}
       </div>
-
       <div className={classes.box}>
         {users &&
           users.map(

--- a/client/src/pages/room/SpectatorList.jsx
+++ b/client/src/pages/room/SpectatorList.jsx
@@ -1,15 +1,36 @@
 import PropTypes from "prop-types";
+import { useSocket } from "../../context/socketContext";
 import User from "./User";
 import useStyles from "../styles";
 
-function UserList({ users, title, capacity, myId, userIsMod }) {
+function SpectatorList({ users, capacity, myId, userIsMod, userIsSpectator }) {
   const classes = useStyles();
+  const { sendMessage } = useSocket();
 
   return (
     <>
-      {title}
-      {capacity &&
-        `: ${users && users.length}/${capacity >= 0 ? capacity : "∞"}`}
+      <div className={classes.flexRow}>
+        <div>
+          Spectators
+          {capacity &&
+            `: ${users && users.length}/${capacity >= 0 ? capacity : "∞"}`}
+        </div>
+        {userIsMod && (
+          <button
+            type="button"
+            className={classes.box}
+            onClick={() =>
+              sendMessage &&
+              sendMessage({
+                type: "unspectateAll",
+              })
+            }
+          >
+            Admit All
+          </button>
+        )}
+      </div>
+
       <div className={classes.box}>
         {users &&
           users.map(
@@ -21,6 +42,7 @@ function UserList({ users, title, capacity, myId, userIsMod }) {
                   userId={user.id}
                   myId={myId}
                   userIsMod={userIsMod}
+                  userIsSpectator
                 />
               )
           )}
@@ -29,21 +51,20 @@ function UserList({ users, title, capacity, myId, userIsMod }) {
   );
 }
 
-UserList.propTypes = {
+SpectatorList.propTypes = {
   users: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
     })
   ).isRequired,
-  title: PropTypes.string.isRequired,
   capacity: PropTypes.number,
   myId: PropTypes.string.isRequired,
   userIsMod: PropTypes.bool.isRequired,
 };
 
-UserList.defaultProps = {
+SpectatorList.defaultProps = {
   capacity: null,
 };
 
-export default UserList;
+export default SpectatorList;

--- a/client/src/pages/room/SpectatorList.jsx
+++ b/client/src/pages/room/SpectatorList.jsx
@@ -7,7 +7,7 @@ function SpectatorList({ users, capacity, myId, userIsMod, userIsSpectator }) {
   const classes = useStyles();
   const { sendMessage } = useSocket();
 
-  return (
+  return users && users.length > 0 ? (
     <>
       <div className={classes.flexRow}>
         <div>
@@ -48,7 +48,7 @@ function SpectatorList({ users, capacity, myId, userIsMod, userIsSpectator }) {
           )}
       </div>
     </>
-  );
+  ) : null;
 }
 
 SpectatorList.propTypes = {

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -5,7 +5,7 @@ import { useSocket } from "../../context/socketContext";
 import useToggle from "../../context/useToggle";
 import useStyles from "./styles";
 
-function User({ name, userId, myId, userIsMod }) {
+function User({ name, userId, myId, userIsMod, userIsSpectator }) {
   const { sendMessage } = useSocket();
   const classes = useStyles();
   const [changingName, setChangingName] = useState(false);
@@ -61,19 +61,36 @@ function User({ name, userId, myId, userIsMod }) {
       </div>
       {myId !== userId ? (
         userIsMod && (
-          <button
-            type="submit"
-            className={classes.banButton}
-            onClick={() =>
-              sendMessage &&
-              sendMessage({
-                type: "banUser",
-                payload: { toBanId: userId },
-              })
-            }
-          >
-            Ban
-          </button>
+          <>
+            <button
+              type="submit"
+              className={classes.banButton}
+              onClick={() =>
+                sendMessage &&
+                sendMessage({
+                  type: "banUser",
+                  payload: { toBanId: userId },
+                })
+              }
+            >
+              Ban
+            </button>
+            {userIsSpectator && (
+              <button
+                type="submit"
+                className={classes.addButton}
+                onClick={() =>
+                  sendMessage &&
+                  sendMessage({
+                    type: "modUnspectate",
+                    payload: { id: userId },
+                  })
+                }
+              >
+                Add
+              </button>
+            )}
+          </>
         )
       ) : (
         <p>Me{userIsMod && ", Mod"}</p>
@@ -87,6 +104,7 @@ User.propTypes = {
   userId: PropTypes.string.isRequired,
   myId: PropTypes.string.isRequired,
   userIsMod: PropTypes.bool.isRequired,
+  userIsSpectator: PropTypes.bool.isRequired,
 };
 
 export default User;

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -104,7 +104,11 @@ User.propTypes = {
   userId: PropTypes.string.isRequired,
   myId: PropTypes.string.isRequired,
   userIsMod: PropTypes.bool.isRequired,
-  userIsSpectator: PropTypes.bool.isRequired,
+  userIsSpectator: PropTypes.bool,
+};
+
+User.defaultProps = {
+  userIsSpectator: false,
 };
 
 export default User;

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -5,7 +5,15 @@ import { useSocket } from "../../context/socketContext";
 import useToggle from "../../context/useToggle";
 import useStyles from "./styles";
 
-function User({ name, userId, myId, userIsMod, userIsSpectator, playerList }) {
+function User({
+  name,
+  userId,
+  myId,
+  userIsMod,
+  userIsSpectator,
+  playerList,
+  inactiveUser,
+}) {
   const { sendMessage } = useSocket();
   const classes = useStyles();
   const [changingName, setChangingName] = useState(false);
@@ -90,19 +98,21 @@ function User({ name, userId, myId, userIsMod, userIsSpectator, playerList }) {
                 Add
               </button>
             )}
-            <button
-              type="submit"
-              className={classes.addButton}
-              onClick={() =>
-                sendMessage &&
-                sendMessage({
-                  type: "nominateMod",
-                  payload: { id: userId },
-                })
-              }
-            >
-              Make Mod
-            </button>
+            {!inactiveUser && (
+              <button
+                type="submit"
+                className={classes.addButton}
+                onClick={() =>
+                  sendMessage &&
+                  sendMessage({
+                    type: "nominateMod",
+                    payload: { id: userId },
+                  })
+                }
+              >
+                Make Mod
+              </button>
+            )}
           </>
         )
       ) : (
@@ -119,11 +129,13 @@ User.propTypes = {
   userIsMod: PropTypes.bool.isRequired,
   userIsSpectator: PropTypes.bool,
   playerList: PropTypes.bool,
+  inactiveUser: PropTypes.bool,
 };
 
 User.defaultProps = {
   userIsSpectator: false,
   playerList: false,
+  inactiveUser: false,
 };
 
 export default User;

--- a/client/src/pages/room/User.jsx
+++ b/client/src/pages/room/User.jsx
@@ -5,7 +5,7 @@ import { useSocket } from "../../context/socketContext";
 import useToggle from "../../context/useToggle";
 import useStyles from "./styles";
 
-function User({ name, userId, myId, userIsMod, userIsSpectator }) {
+function User({ name, userId, myId, userIsMod, userIsSpectator, playerList }) {
   const { sendMessage } = useSocket();
   const classes = useStyles();
   const [changingName, setChangingName] = useState(false);
@@ -90,6 +90,19 @@ function User({ name, userId, myId, userIsMod, userIsSpectator }) {
                 Add
               </button>
             )}
+            <button
+              type="submit"
+              className={classes.addButton}
+              onClick={() =>
+                sendMessage &&
+                sendMessage({
+                  type: "nominateMod",
+                  payload: { id: userId },
+                })
+              }
+            >
+              Make Mod
+            </button>
           </>
         )
       ) : (
@@ -105,10 +118,12 @@ User.propTypes = {
   myId: PropTypes.string.isRequired,
   userIsMod: PropTypes.bool.isRequired,
   userIsSpectator: PropTypes.bool,
+  playerList: PropTypes.bool,
 };
 
 User.defaultProps = {
   userIsSpectator: false,
+  playerList: false,
 };
 
 export default User;

--- a/client/src/pages/room/UserList.jsx
+++ b/client/src/pages/room/UserList.jsx
@@ -5,7 +5,7 @@ import useStyles from "../styles";
 function UserList({ users, title, capacity, myId, userIsMod }) {
   const classes = useStyles();
 
-  return (
+  return users && users.length > 0 ? (
     <>
       {title}
       {capacity &&
@@ -26,7 +26,7 @@ function UserList({ users, title, capacity, myId, userIsMod }) {
           )}
       </div>
     </>
-  );
+  ) : null;
 }
 
 UserList.propTypes = {

--- a/client/src/pages/room/UserList.jsx
+++ b/client/src/pages/room/UserList.jsx
@@ -2,7 +2,14 @@ import PropTypes from "prop-types";
 import User from "./User";
 import useStyles from "../styles";
 
-function UserList({ users, title, capacity, myId, userIsMod }) {
+function UserList({
+  users,
+  title,
+  capacity,
+  myId,
+  userIsMod,
+  userIsSpectator,
+}) {
   const classes = useStyles();
 
   return (
@@ -21,6 +28,7 @@ function UserList({ users, title, capacity, myId, userIsMod }) {
                   userId={user.id}
                   myId={myId}
                   userIsMod={userIsMod}
+                  userIsSpectator={userIsSpectator}
                 />
               )
           )}
@@ -40,6 +48,7 @@ UserList.propTypes = {
   capacity: PropTypes.number,
   myId: PropTypes.string.isRequired,
   userIsMod: PropTypes.bool.isRequired,
+  userIsSpectator: PropTypes.bool.isRequired,
 };
 
 UserList.defaultProps = {

--- a/client/src/pages/room/UserList.jsx
+++ b/client/src/pages/room/UserList.jsx
@@ -21,6 +21,7 @@ function UserList({ users, title, capacity, myId, userIsMod }) {
                   userId={user.id}
                   myId={myId}
                   userIsMod={userIsMod}
+                  inactiveUser
                 />
               )
           )}

--- a/client/src/pages/room/styles.js
+++ b/client/src/pages/room/styles.js
@@ -34,4 +34,9 @@ export default createUseStyles((theme) => ({
     paddingTop: "0.5em",
     paddingBottom: "0.5em",
   },
+  addButton: {
+    border: `2px solid ${theme.green}`,
+    padding: "auto",
+    backgroundColor: theme.white,
+  },
 }));

--- a/client/src/pages/styles.js
+++ b/client/src/pages/styles.js
@@ -60,4 +60,11 @@ export default createUseStyles((theme) => ({
     margin: "auto",
     marginBottom: "2em",
   },
+
+  flexRow: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
 }));

--- a/client/src/theme/theme.js
+++ b/client/src/theme/theme.js
@@ -6,6 +6,7 @@ const theme = {
   ok: "green",
   warn: "orange",
   error: "red",
+  green: "green",
 };
 
 export default theme;

--- a/server/engine/rooms.js
+++ b/server/engine/rooms.js
@@ -147,18 +147,16 @@ class Room {
   }
 
   setSpectate(userId, spectate) {
-    // The user can take no actions in this room if they are banned
     if (this.isBanned(userId)) return undefined;
-
     const index = this.users.findIndex(({ id }) => id === userId);
     if (index < 0) return undefined;
     const user = this.users[index];
     if (!user.present) return undefined;
-
     if (spectate) {
       if (!user.spectate) {
         user.spectate = true;
-        this.promoteSpectator();
+        this.users.splice(index, 1);
+        this.users.push(user);
       }
     } else if (this.canJoinAsPlayer()) {
       if (user.spectate) {
@@ -168,9 +166,11 @@ class Room {
       }
     }
 
+    this.promoteSpectator();
     return user;
   }
 
+  // Allow moderator to set spectate status for another user
   modSetSpectate(modId, userId, spectate) {
     if (!this.isModerator(modId)) return undefined;
     return setSpectate(userId, spectate);

--- a/server/engine/rooms.js
+++ b/server/engine/rooms.js
@@ -185,6 +185,28 @@ class Room {
 
     return this.getUsers();
   }
+
+  makeActive(user) {
+    user.spectate = false;
+    user.present = true;
+
+    return user;
+  }
+
+  nominateMod(modId, newModId) {
+    console.log(`${modId} has nominated ${newModId} to be the new mod`);
+    if (!this.isModerator(modId) || this.isBanned(newModId)) return undefined;
+
+    const index = this.users.findIndex(({ id }) => id === newModId);
+    if (index < 0) return undefined;
+    const user = this.users[index];
+    if (!user.present) return undefined;
+
+    this.users.splice(index, 1);
+    this.users.unshift(user);
+
+    return this.makeActive(user);
+  }
 }
 
 class Rooms {
@@ -244,6 +266,10 @@ class Rooms {
 
   static unspectateAllUsers(name, modId) {
     return this.getRoom(name)?.unspectateAll(modId);
+  }
+
+  static nominateMod(name, modId, newModId) {
+    return this.getRoom(name)?.nominateMod(modId, newModId);
   }
 }
 

--- a/server/engine/rooms.js
+++ b/server/engine/rooms.js
@@ -27,7 +27,7 @@ class Room {
     this.capacity = capacity;
     this.users = [];
     this.numPlayers = 0;
-    this.locked = false;
+    this.locked = true;
   }
 
   getUsers() {
@@ -86,7 +86,7 @@ class Room {
       this.users.splice(index, 1);
     }
     if (index < 0 || !user.present) {
-      // Push (or repush) user if it is new or was inactive
+      // Push (or repush) user if they are new or were inactive
       if (this.canJoinAsPlayer()) {
         if (!user.spectate) this.numPlayers += 1;
       } else {
@@ -113,6 +113,17 @@ class Room {
     if (user.count === 0) {
       if (!user.spectate) this.numPlayers -= 1;
       user.present = false;
+    }
+
+    // if there are no more players, promote a spectator
+    if (this.numPlayers === 0) {
+      const { players, inactives, spectators, banned } = this.getUsers();
+      if (spectators.length >= 0) {
+        spectators[0].spectate = false;
+        // but if there are no more spectators, close the room
+      } else {
+        // close the room?
+      }
     }
 
     return user;
@@ -152,6 +163,11 @@ class Room {
     }
 
     return user;
+  }
+
+  modSetSpectate(modId, userId, spectate) {
+    if (!this.isModerator(modId)) return undefined;
+    return setSpectate(userId, spectate);
   }
 }
 

--- a/server/engine/rooms.js
+++ b/server/engine/rooms.js
@@ -30,6 +30,10 @@ class Room {
     this.locked = true;
   }
 
+  getNumPlayers() {
+    return this.getUsers().players.length;
+  }
+
   getUsers() {
     const players = [];
     const inactives = [];
@@ -97,7 +101,25 @@ class Room {
     user.present = true;
     user.count += 1;
 
+    this.promoteSpectator();
+
     return user;
+  }
+
+  promoteSpectator() {
+    // if there are no more players, promote a spectator
+    if (this.getNumPlayers() === 0) {
+      const { players, inactives, spectators, banned } = this.getUsers();
+      console.log(players, inactives, spectators, banned, this.users);
+      if (spectators.length > 0) {
+        const upgradee = spectators[0].id;
+        console.log(`Upgrading spectator ${upgradee} to moderator!`);
+        this.getUser(upgradee).spectate = false;
+        // but if there are no more spectators, close the room
+      } else {
+        // close the room?
+      }
+    }
   }
 
   leave(userId) {
@@ -115,17 +137,7 @@ class Room {
       user.present = false;
     }
 
-    // if there are no more players, promote a spectator
-    if (this.numPlayers === 0) {
-      const { players, inactives, spectators, banned } = this.getUsers();
-      if (spectators.length >= 0) {
-        spectators[0].spectate = false;
-        // but if there are no more spectators, close the room
-      } else {
-        // close the room?
-      }
-    }
-
+    this.promoteSpectator();
     return user;
   }
 
@@ -152,6 +164,7 @@ class Room {
       if (!user.spectate) {
         user.spectate = true;
         this.numPlayers -= 1;
+        this.promoteSpectator();
       }
     } else if (this.canJoinAsPlayer()) {
       if (user.spectate) {

--- a/server/engine/rooms.js
+++ b/server/engine/rooms.js
@@ -106,7 +106,7 @@ class Room {
   promoteSpectator() {
     // if there are no more players, promote a spectator
     if (this.getNumPlayers() === 0) {
-      const { players, inactives, spectators, banned } = this.getUsers();
+      const { spectators } = this.getUsers();
       if (spectators.length > 0) {
         const upgradee = spectators[0].id;
         console.log(`Upgrading spectator ${upgradee} to moderator!`);
@@ -182,6 +182,8 @@ class Room {
 
     const { spectators } = this.getUsers();
     spectators.forEach(({ id }) => this.setSpectate(id, false, true));
+
+    return this.getUsers();
   }
 }
 

--- a/server/engine/rooms.js
+++ b/server/engine/rooms.js
@@ -186,13 +186,6 @@ class Room {
     return this.getUsers();
   }
 
-  makeActive(user) {
-    user.spectate = false;
-    user.present = true;
-
-    return user;
-  }
-
   nominateMod(modId, newModId) {
     console.log(`${modId} has nominated ${newModId} to be the new mod`);
     if (!this.isModerator(modId) || this.isBanned(newModId)) return undefined;
@@ -203,9 +196,10 @@ class Room {
     if (!user.present) return undefined;
 
     this.users.splice(index, 1);
+    user.spectate = false;
     this.users.unshift(user);
 
-    return this.makeActive(user);
+    return user;
   }
 }
 

--- a/server/engine/rooms.js
+++ b/server/engine/rooms.js
@@ -26,7 +26,6 @@ class Room {
     this.name = name;
     this.capacity = capacity;
     this.users = [];
-    this.numPlayers = 0;
     this.locked = true;
   }
 
@@ -53,7 +52,7 @@ class Room {
 
   canJoinAsPlayer() {
     if (this.locked) return false;
-    return this.capacity < 0 || this.numPlayers < this.capacity;
+    return this.capacity < 0 || this.getNumPlayers() < this.capacity;
   }
 
   getCurrentPlayers() {
@@ -62,7 +61,9 @@ class Room {
 
   isModerator(userId) {
     // The moderator is the first added active player.
-    return this.numPlayers > 0 && userId === this.getCurrentPlayers()[0].id;
+    return (
+      this.getNumPlayers() > 0 && userId === this.getCurrentPlayers()[0].id
+    );
   }
 
   isBanned(userId) {
@@ -91,11 +92,7 @@ class Room {
     }
     if (index < 0 || !user.present) {
       // Push (or repush) user if they are new or were inactive
-      if (this.canJoinAsPlayer()) {
-        if (!user.spectate) this.numPlayers += 1;
-      } else {
-        user.spectate = true;
-      }
+      if (!this.canJoinAsPlayer()) user.spectate = true;
       this.users.push(user);
     }
     user.present = true;
@@ -110,7 +107,6 @@ class Room {
     // if there are no more players, promote a spectator
     if (this.getNumPlayers() === 0) {
       const { players, inactives, spectators, banned } = this.getUsers();
-      console.log(players, inactives, spectators, banned, this.users);
       if (spectators.length > 0) {
         const upgradee = spectators[0].id;
         console.log(`Upgrading spectator ${upgradee} to moderator!`);
@@ -133,7 +129,6 @@ class Room {
 
     user.count -= 1;
     if (user.count === 0) {
-      if (!user.spectate) this.numPlayers -= 1;
       user.present = false;
     }
 
@@ -163,7 +158,6 @@ class Room {
     if (spectate) {
       if (!user.spectate) {
         user.spectate = true;
-        this.numPlayers -= 1;
         this.promoteSpectator();
       }
     } else if (this.canJoinAsPlayer()) {
@@ -171,7 +165,6 @@ class Room {
         user.spectate = false;
         this.users.splice(index, 1);
         this.users.push(user);
-        this.numPlayers += 1;
       }
     }
 

--- a/server/engine/rooms.js
+++ b/server/engine/rooms.js
@@ -146,7 +146,8 @@ class Room {
     return bannedUser;
   }
 
-  setSpectate(userId, spectate) {
+  setSpectate(userId, spectate, byMod) {
+    console.log(`Setting ${userId}'s spectate status to ${spectate}`);
     if (this.isBanned(userId)) return undefined;
     const index = this.users.findIndex(({ id }) => id === userId);
     if (index < 0) return undefined;
@@ -158,7 +159,7 @@ class Room {
         this.users.splice(index, 1);
         this.users.push(user);
       }
-    } else if (this.canJoinAsPlayer()) {
+    } else if (this.canJoinAsPlayer() || byMod) {
       if (user.spectate) {
         user.spectate = false;
         this.users.splice(index, 1);
@@ -173,7 +174,7 @@ class Room {
   // Allow moderator to set spectate status for another user
   modSetSpectate(modId, userId, spectate) {
     if (!this.isModerator(modId)) return undefined;
-    return setSpectate(userId, spectate);
+    return this.setSpectate(userId, spectate, true);
   }
 }
 
@@ -226,6 +227,10 @@ class Rooms {
 
   static banUser(name, userId, toBanId) {
     return this.getRoom(name)?.ban(userId, toBanId);
+  }
+
+  static modSetSpectate(name, modId, toSetId, spectate) {
+    return this.getRoom(name)?.modSetSpectate(modId, toSetId, spectate);
   }
 }
 

--- a/server/engine/rooms.js
+++ b/server/engine/rooms.js
@@ -176,6 +176,13 @@ class Room {
     if (!this.isModerator(modId)) return undefined;
     return this.setSpectate(userId, spectate, true);
   }
+
+  unspectateAll(modId) {
+    if (!this.isModerator(modId)) return undefined;
+
+    const { spectators } = this.getUsers();
+    spectators.forEach(({ id }) => this.setSpectate(id, false, true));
+  }
 }
 
 class Rooms {
@@ -231,6 +238,10 @@ class Rooms {
 
   static modSetSpectate(name, modId, toSetId, spectate) {
     return this.getRoom(name)?.modSetSpectate(modId, toSetId, spectate);
+  }
+
+  static unspectateAllUsers(name, modId) {
+    return this.getRoom(name)?.unspectateAll(modId);
   }
 }
 

--- a/server/sockets/socketActions.js
+++ b/server/sockets/socketActions.js
@@ -49,6 +49,11 @@ function modUnspectate(wss, message, { roomName, userId }) {
   updateUsers(wss, message, { roomName });
 }
 
+function unspectateAll(wss, message, { roomName, userId }) {
+  Rooms.unspectateAllUsers(roomName, userId);
+  updateUsers(wss, message, { roomName });
+}
+
 const socketActions = {
   connect,
   disconnect,
@@ -58,6 +63,7 @@ const socketActions = {
   banUser,
   changeName,
   modUnspectate,
+  unspectateAll,
 };
 
 module.exports = socketActions;

--- a/server/sockets/socketActions.js
+++ b/server/sockets/socketActions.js
@@ -54,6 +54,11 @@ function unspectateAll(wss, message, { roomName, userId }) {
   updateUsers(wss, message, { roomName });
 }
 
+function nominateMod(wss, message, { roomName, userId }) {
+  Rooms.nominateMod(roomName, userId, message.payload.id);
+  updateUsers(wss, message, { roomName });
+}
+
 const socketActions = {
   connect,
   disconnect,
@@ -64,6 +69,7 @@ const socketActions = {
   changeName,
   modUnspectate,
   unspectateAll,
+  nominateMod,
 };
 
 module.exports = socketActions;

--- a/server/sockets/socketActions.js
+++ b/server/sockets/socketActions.js
@@ -44,6 +44,11 @@ function changeName(wss, message, { roomName, userId }) {
   updateUsers(wss, message, { roomName });
 }
 
+function modUnspectate(wss, message, { roomName, userId }) {
+  Rooms.modSetSpectate(roomName, userId, message.payload.id, false);
+  updateUsers(wss, message, { roomName });
+}
+
 const socketActions = {
   connect,
   disconnect,
@@ -52,6 +57,7 @@ const socketActions = {
   unspectate,
   banUser,
   changeName,
+  modUnspectate,
 };
 
 module.exports = socketActions;


### PR DESCRIPTION
Changes to user flow:
- users enter as spectators by default (except for the creator of the room)
- any player can make themselves a spectator
- the moderator can also admit anyone into the room (spectator -> player). 
- individual 'admit' buttons for each player as well as an admitAll button exist to add everyone waiting to the game
- if the moderator leaves the room and there are no other active players, the first spectator becomes a player (and thus the current moderator)

Other changes:
- lists of users are hidden if they have no members
- spectate button is only visible if it is a valid action for the user
- the current mod can now pass their power to anyone else in the room rather than just to the next user