### PR TITLE
Import server from client

### DIFF
--- a/client/babel.config.json
+++ b/client/babel.config.json
@@ -1,0 +1,7 @@
+{
+  "presets": ["@babel/preset-react"],
+  "plugins": [
+    "@babel/plugin-syntax-class-properties",
+    "@babel/plugin-proposal-class-properties"
+  ]
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,9 +1,9 @@
 {
   "name": "client",
   "version": "0.0.0",
-  "private": true,
   "proxy": "http://localhost:4000",
   "dependencies": {
+    "server": "*",
     "@babel/core": "7.12.3",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@svgr/webpack": "5.5.0",

--- a/client/src/context/socketContext.jsx
+++ b/client/src/context/socketContext.jsx
@@ -10,6 +10,7 @@ import PropTypes from "prop-types";
 import useWebSocket from "react-use-websocket";
 import { useUser } from "./userContext";
 import spec from "../api_schema.json";
+import { clientConfig, serverConfig } from "server";
 
 const SocketContext = createContext(null);
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,6 @@
 {
   "name": "server",
   "version": "0.0.0",
-  "private": true,
   "main": "index.js",
   "scripts": {
     "start": "node ./bin/www"


### PR DESCRIPTION
closes #21 
this is good because importing server api directly from the client is absolutely incredible, even if it means extra boilerplate on the server is required to handle it